### PR TITLE
replace all selem with footprint

### DIFF
--- a/PCfunctions.py
+++ b/PCfunctions.py
@@ -7,6 +7,7 @@ import numpy as np
 import cv2
 from skimage import measure as meas
 from skimage import morphology as morph
+from skimage.morphology import (square, disk)
 from osgeo import gdal
 from scipy.sparse import csr_matrix
 
@@ -215,8 +216,8 @@ class pick_colors:
             image_mask = np.invert(image_mask).astype(bool)
             # clean it up
             image_mask = morph.remove_small_holes(image_mask, area_threshold=10, connectivity=2)
-            image_mask = morph.opening(image_mask, footprint=morph.footprint.disk(1))
-            image_mask = morph.closing(image_mask, footprint=morph.footprint.disk(1))
+            image_mask = morph.opening(image_mask, footprint=disk(1))
+            image_mask = morph.closing(image_mask, footprint=disk(1))
             image_mask = image_mask.astype(np.uint8)
             image_mask[image_mask==0] = 255
             image_mask[image_mask==1] = 0

--- a/PCfunctions.py
+++ b/PCfunctions.py
@@ -215,8 +215,8 @@ class pick_colors:
             image_mask = np.invert(image_mask).astype(bool)
             # clean it up
             image_mask = morph.remove_small_holes(image_mask, area_threshold=10, connectivity=2)
-            image_mask = morph.opening(image_mask, selem=morph.selem.disk(1))
-            image_mask = morph.closing(image_mask, selem=morph.selem.disk(1))
+            image_mask = morph.opening(image_mask, footprint=morph.footprint.disk(1))
+            image_mask = morph.closing(image_mask, footprint=morph.footprint.disk(1))
             image_mask = image_mask.astype(np.uint8)
             image_mask[image_mask==0] = 255
             image_mask[image_mask==1] = 0

--- a/PCfunctions.py
+++ b/PCfunctions.py
@@ -16,7 +16,7 @@ def resizeWin(img, resize_factor=0.7):
     must be in the range (0, 1].
     """
     from sys import platform as sys_pf
-    if 'win' in sys_pf:
+    if sys_pf != 'darwin':
         # this import needs to be within the function or else openCV throws errors
         import tkinter as tk
         root = tk.Tk()

--- a/PebbleCounts.py
+++ b/PebbleCounts.py
@@ -313,8 +313,8 @@ else:
             color_mask = np.invert(color_mask).astype(bool)
             # clean it up
             color_mask = morph.remove_small_holes(color_mask, area_threshold=min_sizes[-1], connectivity=2)
-            color_mask = morph.opening(color_mask, selem=morph.selem.disk(1))
-            color_mask = morph.closing(color_mask, selem=morph.selem.disk(1))
+            color_mask = morph.opening(color_mask, footprint=morph.footprint.disk(1))
+            color_mask = morph.closing(color_mask, footprint=morph.footprint.disk(1))
             # add the hue mask to the full ignore mask
             ignore_mask = np.logical_and(ignore_mask, color_mask)
             # make the color mask three channel image for stacking
@@ -421,7 +421,7 @@ for index in range(len(windowSizes)):
 
         # tophat edges
         print("Black tophat edge detection")
-        tophat = morph.black_tophat(GRAY, selem=morph.selem.disk(1))
+        tophat = morph.black_tophat(GRAY, footprint=morph.footprint.disk(1))
         tophat = tophat < np.percentile(tophat, tophat_th)
         tophat = morph.remove_small_holes(tophat, area_threshold=5, connectivity=2)
         if not np.sum(tophat) == 0:
@@ -510,8 +510,8 @@ for index in range(len(windowSizes)):
             mask[mask != True] = False
             # binary operations to clean the mask a bit
             mask = morph.remove_small_objects(mask, min_size=min_size, connectivity=2)
-            mask = morph.erosion(mask, selem=morph.selem.square(3))
-            mask = morph.dilation(mask, selem=morph.selem.square(2))
+            mask = morph.erosion(mask, footprint=morph.footprint.square(3))
+            mask = morph.dilation(mask, footprint=morph.footprint.square(2))
             mask = segm.clear_border(mask)
             mask = morph.remove_small_objects(mask, min_size=min_size, connectivity=2)
             # make sure we didn't add any pixels back in from the original mask
@@ -532,7 +532,7 @@ for index in range(len(windowSizes)):
         # eliminate any regions that are smaller than cutoff value
         tmp, num = ndi.label(master_mask[:,:,0])
         for region in meas.regionprops(tmp):
-            grain_dil_ = morph.dilation(region.image, selem=morph.selem.square(2)).astype(int)
+            grain_dil_ = morph.dilation(region.image, footprint=morph.footprint.square(2)).astype(int)
             grain_dil_ = np.pad(grain_dil_, ((1, 1), (1,1)), 'constant')
             b_ = meas.regionprops(grain_dil_)[0].minor_axis_length
             a_ = meas.regionprops(grain_dil_)[0].major_axis_length
@@ -595,7 +595,7 @@ for index in range(len(windowSizes)):
             labels, _ = ndi.label(labels)
             for grain in meas.regionprops(labels):
                 # dilate the grains
-                grain_dil = morph.dilation(grain.image, selem=morph.selem.square(2)).astype(int)
+                grain_dil = morph.dilation(grain.image, footprint=morph.footprint.square(2)).astype(int)
                 grain_dil = np.pad(grain_dil, ((1, 1), (1,1)), 'constant')
                 b = meas.regionprops(grain_dil)[0].minor_axis_length
                 a = meas.regionprops(grain_dil)[0].major_axis_length

--- a/PebbleCounts.py
+++ b/PebbleCounts.py
@@ -19,6 +19,7 @@ from skimage import measure as meas
 from skimage import segmentation as segm
 from skimage import feature as feat
 from skimage import morphology as morph
+from skimage.morphology import (square, disk)
 from skimage import filters as filt
 import matplotlib.pyplot as plt
 from matplotlib.path import Path
@@ -313,8 +314,8 @@ else:
             color_mask = np.invert(color_mask).astype(bool)
             # clean it up
             color_mask = morph.remove_small_holes(color_mask, area_threshold=min_sizes[-1], connectivity=2)
-            color_mask = morph.opening(color_mask, footprint=morph.footprint.disk(1))
-            color_mask = morph.closing(color_mask, footprint=morph.footprint.disk(1))
+            color_mask = morph.opening(color_mask, footprint=disk(1))
+            color_mask = morph.closing(color_mask, footprint=disk(1))
             # add the hue mask to the full ignore mask
             ignore_mask = np.logical_and(ignore_mask, color_mask)
             # make the color mask three channel image for stacking
@@ -421,7 +422,7 @@ for index in range(len(windowSizes)):
 
         # tophat edges
         print("Black tophat edge detection")
-        tophat = morph.black_tophat(GRAY, footprint=morph.footprint.disk(1))
+        tophat = morph.black_tophat(GRAY, footprint=disk(1))
         tophat = tophat < np.percentile(tophat, tophat_th)
         tophat = morph.remove_small_holes(tophat, area_threshold=5, connectivity=2)
         if not np.sum(tophat) == 0:
@@ -510,8 +511,8 @@ for index in range(len(windowSizes)):
             mask[mask != True] = False
             # binary operations to clean the mask a bit
             mask = morph.remove_small_objects(mask, min_size=min_size, connectivity=2)
-            mask = morph.erosion(mask, footprint=morph.footprint.square(3))
-            mask = morph.dilation(mask, footprint=morph.footprint.square(2))
+            mask = morph.erosion(mask, footprint=square(3))
+            mask = morph.dilation(mask, footprint=square(2))
             mask = segm.clear_border(mask)
             mask = morph.remove_small_objects(mask, min_size=min_size, connectivity=2)
             # make sure we didn't add any pixels back in from the original mask
@@ -532,7 +533,7 @@ for index in range(len(windowSizes)):
         # eliminate any regions that are smaller than cutoff value
         tmp, num = ndi.label(master_mask[:,:,0])
         for region in meas.regionprops(tmp):
-            grain_dil_ = morph.dilation(region.image, footprint=morph.footprint.square(2)).astype(int)
+            grain_dil_ = morph.dilation(region.image, footprint=square(2)).astype(int)
             grain_dil_ = np.pad(grain_dil_, ((1, 1), (1,1)), 'constant')
             b_ = meas.regionprops(grain_dil_)[0].minor_axis_length
             a_ = meas.regionprops(grain_dil_)[0].major_axis_length
@@ -595,7 +596,7 @@ for index in range(len(windowSizes)):
             labels, _ = ndi.label(labels)
             for grain in meas.regionprops(labels):
                 # dilate the grains
-                grain_dil = morph.dilation(grain.image, footprint=morph.footprint.square(2)).astype(int)
+                grain_dil = morph.dilation(grain.image, footprint=square(2)).astype(int)
                 grain_dil = np.pad(grain_dil, ((1, 1), (1,1)), 'constant')
                 b = meas.regionprops(grain_dil)[0].minor_axis_length
                 a = meas.regionprops(grain_dil)[0].major_axis_length

--- a/PebbleCountsAuto.py
+++ b/PebbleCountsAuto.py
@@ -18,6 +18,7 @@ from skimage import measure as meas
 from skimage import segmentation as segm
 from skimage import feature as feat
 from skimage import morphology as morph
+from skimage.morphology import (square, disk)
 from skimage import filters as filt
 import matplotlib.pyplot as plt
 from matplotlib.path import Path
@@ -275,8 +276,8 @@ else:
             color_mask = np.invert(color_mask).astype(bool)
             # clean it up
             color_mask = morph.remove_small_holes(color_mask, area_threshold=min_size, connectivity=2)
-            color_mask = morph.opening(color_mask, footprint=morph.footprint.disk(1))
-            color_mask = morph.closing(color_mask, footprint=morph.footprint.disk(1))
+            color_mask = morph.opening(color_mask, footprint=disk(1))
+            color_mask = morph.closing(color_mask, footprint=disk(1))
             # add the hue mask to the full ignore mask
             ignore_mask = np.logical_and(ignore_mask, color_mask)
             # make the color mask three channel image for stacking
@@ -335,7 +336,7 @@ print("\nBeginning segmentation")
 
 # tophat edges
 print("Black tophat edge detection")
-tophat = morph.black_tophat(gray, footprint=morph.footprint.disk(1))
+tophat = morph.black_tophat(gray, footprint=disk(1))
 tophat = tophat < np.percentile(tophat, tophat_th)
 tophat = morph.remove_small_holes(tophat, area_threshold=5, connectivity=2)
 if not np.sum(tophat) == 0:
@@ -359,8 +360,8 @@ ignore_mask = np.logical_and(foo, ignore_mask)
 
 # cleanup the mask
 master_mask = morph.remove_small_objects(ignore_mask, min_size=min_size, connectivity=2)
-master_mask = morph.erosion(master_mask, footprint=morph.footprint.square(3))
-master_mask = morph.dilation(master_mask, footprint=morph.footprint.square(2))
+master_mask = morph.erosion(master_mask, footprint=square(3))
+master_mask = morph.dilation(master_mask, footprint=square(2))
 master_mask = segm.clear_border(master_mask)
 master_mask = morph.remove_small_objects(master_mask, min_size=min_size, connectivity=2)
 # make sure we didn't accidently add any definite edges back in
@@ -369,7 +370,7 @@ master_mask[ignore_mask == False] = False
 # eliminate any regions that are smaller than cutoff value
 tmp, num = ndi.label(master_mask)
 for region in meas.regionprops(tmp):
-    grain_dil_ = morph.dilation(region.image, footprint=morph.footprint.square(2)).astype(int)
+    grain_dil_ = morph.dilation(region.image, footprint=square(2)).astype(int)
     grain_dil_ = np.pad(grain_dil_, ((1, 1), (1,1)), 'constant')
     b_ = meas.regionprops(grain_dil_)[0].minor_axis_length
     a_ = meas.regionprops(grain_dil_)[0].major_axis_length
@@ -389,7 +390,7 @@ print("Getting grain properties")
 labels, _ = ndi.label(master_mask)
 for grain in meas.regionprops(labels):
     # dilate the grain before getting measurements
-    grain_dil = morph.dilation(grain.image, footprint=morph.footprint.square(2)).astype(int)
+    grain_dil = morph.dilation(grain.image, footprint=square(2)).astype(int)
     grain_dil = np.pad(grain_dil, ((1, 1), (1,1)), 'constant')
     b = meas.regionprops(grain_dil)[0].minor_axis_length
     a = meas.regionprops(grain_dil)[0].major_axis_length

--- a/PebbleCountsAuto.py
+++ b/PebbleCountsAuto.py
@@ -275,8 +275,8 @@ else:
             color_mask = np.invert(color_mask).astype(bool)
             # clean it up
             color_mask = morph.remove_small_holes(color_mask, area_threshold=min_size, connectivity=2)
-            color_mask = morph.opening(color_mask, selem=morph.selem.disk(1))
-            color_mask = morph.closing(color_mask, selem=morph.selem.disk(1))
+            color_mask = morph.opening(color_mask, footprint=morph.footprint.disk(1))
+            color_mask = morph.closing(color_mask, footprint=morph.footprint.disk(1))
             # add the hue mask to the full ignore mask
             ignore_mask = np.logical_and(ignore_mask, color_mask)
             # make the color mask three channel image for stacking
@@ -335,7 +335,7 @@ print("\nBeginning segmentation")
 
 # tophat edges
 print("Black tophat edge detection")
-tophat = morph.black_tophat(gray, selem=morph.selem.disk(1))
+tophat = morph.black_tophat(gray, footprint=morph.footprint.disk(1))
 tophat = tophat < np.percentile(tophat, tophat_th)
 tophat = morph.remove_small_holes(tophat, area_threshold=5, connectivity=2)
 if not np.sum(tophat) == 0:
@@ -359,8 +359,8 @@ ignore_mask = np.logical_and(foo, ignore_mask)
 
 # cleanup the mask
 master_mask = morph.remove_small_objects(ignore_mask, min_size=min_size, connectivity=2)
-master_mask = morph.erosion(master_mask, selem=morph.selem.square(3))
-master_mask = morph.dilation(master_mask, selem=morph.selem.square(2))
+master_mask = morph.erosion(master_mask, footprint=morph.footprint.square(3))
+master_mask = morph.dilation(master_mask, footprint=morph.footprint.square(2))
 master_mask = segm.clear_border(master_mask)
 master_mask = morph.remove_small_objects(master_mask, min_size=min_size, connectivity=2)
 # make sure we didn't accidently add any definite edges back in
@@ -369,7 +369,7 @@ master_mask[ignore_mask == False] = False
 # eliminate any regions that are smaller than cutoff value
 tmp, num = ndi.label(master_mask)
 for region in meas.regionprops(tmp):
-    grain_dil_ = morph.dilation(region.image, selem=morph.selem.square(2)).astype(int)
+    grain_dil_ = morph.dilation(region.image, footprint=morph.footprint.square(2)).astype(int)
     grain_dil_ = np.pad(grain_dil_, ((1, 1), (1,1)), 'constant')
     b_ = meas.regionprops(grain_dil_)[0].minor_axis_length
     a_ = meas.regionprops(grain_dil_)[0].major_axis_length
@@ -389,7 +389,7 @@ print("Getting grain properties")
 labels, _ = ndi.label(master_mask)
 for grain in meas.regionprops(labels):
     # dilate the grain before getting measurements
-    grain_dil = morph.dilation(grain.image, selem=morph.selem.square(2)).astype(int)
+    grain_dil = morph.dilation(grain.image, footprint=morph.footprint.square(2)).astype(int)
     grain_dil = np.pad(grain_dil, ((1, 1), (1,1)), 'constant')
     b = meas.regionprops(grain_dil)[0].minor_axis_length
     a = meas.regionprops(grain_dil)[0].major_axis_length


### PR DESCRIPTION
`selem` has been deprecated in scikit-image. replace with `footprint`.

https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3736